### PR TITLE
Fix deleted records not raising DeletedRecordError upon method_missing

### DIFF
--- a/lib/sierra_postgres_utilities/data/records/deleted.rb
+++ b/lib/sierra_postgres_utilities/data/records/deleted.rb
@@ -17,7 +17,7 @@ module Sierra
       # We don't know whether it was a bib/item/other_record_type method
       # being called on this deleted record, but we want to warn especially
       # in case it was.
-      def method_missing
+      def method_missing(method_name, *arguments, &block)
         raise DeletedRecordError, "Deleted record #{record_type_code}" \
         "#{record_num} lacks methods associated with undeleted records."
       end

--- a/lib/sierra_postgres_utilities/version.rb
+++ b/lib/sierra_postgres_utilities/version.rb
@@ -1,3 +1,3 @@
 module Sierra
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/data/record/deleted_spec.rb
+++ b/spec/data/record/deleted_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Sierra::Data::DeletedRecord do
+  let(:rec) { Sierra::Data::Metadata.first.extend Sierra::Data::DeletedRecord }
+
+  it 'raises a DeletedRecordError on method_missing' do
+    expect{ rec.non_existent_method }.
+      to raise_error(Sierra::Data::DeletedRecord::DeletedRecordError)
+  end
+end


### PR DESCRIPTION
Overwriting of method_missing for DeletedRecord's was off, resulting in an ArgumentError prior to raising the desired DeletedRecordError.