### PR TITLE
Bump bundler per dependabot

### DIFF
--- a/sierra_postgres_utilities.gemspec
+++ b/sierra_postgres_utilities.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.2', '>= 2.2.19'
   spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'factory_bot', '~> 5.0.0'


### PR DESCRIPTION
Bumping to >=2.2.19 to include bug fixes, though dependabot only requires >= 2.2.18