### PR TITLE
APPDEV-9947 add factories

### DIFF
--- a/lib/sierra_postgres_utilities/version.rb
+++ b/lib/sierra_postgres_utilities/version.rb
@@ -1,3 +1,3 @@
 module Sierra
-  VERSION = '0.3.4'.freeze
+  VERSION = '0.3.5'.freeze
 end

--- a/spec/data/fields/leaderfield_spec.rb
+++ b/spec/data/fields/leaderfield_spec.rb
@@ -14,19 +14,19 @@ describe Sierra::Data::LeaderField do
       expect(subject.length).to eq(24)
     end
 
-    it 'uses dummy values for record length (ldr/00-04)' do
+    it 'uses pseudo values for record length (ldr/00-04)' do
       expect(subject[0..4]).to eq('00000')
     end
 
-    it 'uses dummy values for indicator count (ldr/10)' do
+    it 'uses pseudo values for indicator count (ldr/10)' do
       expect(subject[10]).to eq('2')
     end
 
-    it 'uses dummy values for subfield code count (ldr/11)' do
+    it 'uses pseudo values for subfield code count (ldr/11)' do
       expect(subject[11]).to eq('2')
     end
 
-    it 'uses dummy values for misc tail values (ldr/20-23)' do
+    it 'uses pseudo values for misc tail values (ldr/20-23)' do
       expect(subject[20..23]).to eq('4500')
     end
   end

--- a/spec/data/fields/varfield_spec.rb
+++ b/spec/data/fields/varfield_spec.rb
@@ -72,7 +72,8 @@ describe Sierra::Data::Varfield do
           expect(v245.to_marc).to eq(
             MARC::DataField.new('245', '1', '0',
                                 ['a', 'Something else :'],
-                                ['b', 'a novel'])
+                                ['b', 'a novel /'],
+                                ['c', 'Virginia Fassnidge.'])
           )
         end
       end

--- a/spec/data/helpers/sierra_marc_spec.rb
+++ b/spec/data/helpers/sierra_marc_spec.rb
@@ -24,11 +24,21 @@ module Sierra
                 expect(bib.marc).to be_a(MARC::Record)
               end
 
-              it 'contains correct marc fields' do
-                expect(bib.marc.fields).to eq(correct_mrc.fields)
+              it 'contains correct marc fields', :aggregate_failures do
+                marc_bib = newrec(Sierra::Data::Bib, build(:metadata_b), build(:data_b))
+                marc_bib.set_data(:control_fields, [build(:control_008)])
+                marc_bib.set_data(
+                  :varfields,
+                  [build(:varfield_001), build(:varfield_005), build(:varfield_245),
+                   ]
+                )
+                expect(marc_bib.marc['001'].to_s).to eq('001 8671134')
+                expect(marc_bib.marc['005'].to_s).to eq('005 19820807000000.0')
+                expect(marc_bib.marc['008'].to_s).to eq('008 140912n| azannaabn          |n aaa      ')
+                expect(marc_bib.marc['245'].to_s).to eq('245 10 $a Something else : $b a novel / $c Virginia Fassnidge. ')
               end
 
-              it 'returns proper leader, apart from dummied fields/chars' do
+              it 'returns proper leader, apart from pseudo-value fields/chars' do
                 bib.marc.leader[0..4] = '00000'
                 bib.marc.leader[12..16] = '00000'
                 correct_mrc.leader[0..4] = '00000'

--- a/spec/data/record/item_spec.rb
+++ b/spec/data/record/item_spec.rb
@@ -141,6 +141,9 @@ describe Sierra::Data::Item do
 
   describe '#location_desc' do
     it 'returns location description / longname' do
+      location = build(:loc_trln)
+      location.instance_variable_set(:@name, 'Library Service Center — Request from Storage')
+      item.set_data(:location, location)
       expect(
         item.location_desc
       ).to eq('Library Service Center — Request from Storage')

--- a/spec/factories/holdings_card.rb
+++ b/spec/factories/holdings_card.rb
@@ -1,0 +1,20 @@
+module Sierra
+  module Data
+    FactoryBot.define do
+      factory :holdings_card, class: HoldingsCard do
+        id { 26716 }
+        holding_record_id { 425206860854 }
+        status_code { 'C' }
+        display_format_code { nil }
+        is_suppress_opac_display { nil }
+        order_record_metadata_id { nil }
+        is_create_item { false }
+        is_usmarc { true }
+        is_marc { nil }
+        is_use_default_enum { nil }
+        is_use_default_date { nil }
+        update_method_code { 'n' }
+      end
+    end
+  end
+end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -12,6 +12,10 @@ module Sierra
           code { 'ddda' }
         end
 
+        factory :loc_trln do
+          code { 'trln' }
+        end
+
         factory :loc_wbba do
           code { 'wbba' }
         end

--- a/spec/factories/varfield.rb
+++ b/spec/factories/varfield.rb
@@ -16,12 +16,24 @@ module Sierra
           field_content { '|aSomething else :|ba novel' }
 
           factory :varfield_245 do
+            field_content { '|aSomething else :|ba novel /|cVirginia Fassnidge.' }
+          end
+
+          factory :varfield_001 do
+            marc_tag { '001' }
+            field_content { '8671134' }
           end
 
           factory :varfield_005 do
             marc_tag { '005' }
             varfield_type_code { 'y' }
             field_content { '19820807000000.0' }
+          end
+
+          factory :varfield_852 do
+            marc_tag { '852' }
+            varfield_type_code { 'c' }
+            field_content { '|hQV 704|iR388|zEarlier editions in stacks' }
           end
 
           factory :varfield_implicit_sfa do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,13 +8,6 @@ RSpec.configure do |config|
   FactoryBot.find_definitions
 end
 
-def dummy_set(hsh)
-  hsh.each do |k, v|
-    dummy.data.send(:"#{k}=", v)
-  end
-  dummy
-end
-
 module Sierra
   module SpecUtils
     module Records


### PR DESCRIPTION
- Adds holdings_cards and holdings factories (used downstream)
- Use factories in cases of failing specs that were dependent on live data
- Remove some problematic language